### PR TITLE
orpaned docker containers and unused image cleanup

### DIFF
--- a/cleanup-docker.sh
+++ b/cleanup-docker.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Clean up docker machine containers and images
+
+# Clean up old docker containers
+_OLD_CONTAINERS="$(docker ps -a -q)"
+if [[ -z ${_OLD_CONTAINERS} ]] 
+then
+    echo "No old containers to remove"
+else
+    echo "Removing old container images"
+    docker rm ${_OLD_CONTAINERS}
+fi
+
+# Clean up orphaned docker images
+_OLD_IMAGES="$(docker images | grep '^<none>' | awk '{print $3}')"
+if [[ -z ${_OLD_IMAGES} ]]
+then
+    echo "No orphaned images to remove"
+else
+    echo "Removing orphaned docker images"
+    docker rmi ${_OLD_IMAGES}
+fi


### PR DESCRIPTION
If we continuously keep building and running containers there are a lot of orphaned containers and old images that get accumulated on the docker machine. A new script is created that the user can run to clean up his environment and save on disk space as well.

Future enhancement: Ideally this can be integrated with the maven build process so that during a 'mvn clean' call this script is called to take care of this automatically.