### PR TITLE
Enabled LogLevel Management via JMX for API Server

### DIFF
--- a/shardis-api/pom.xml
+++ b/shardis-api/pom.xml
@@ -60,6 +60,10 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/shardis-api/src/main/resources/logback.xml
+++ b/shardis-api/src/main/resources/logback.xml
@@ -1,0 +1,4 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <jmxConfigurator/>
+</configuration>


### PR DESCRIPTION
As a sample of how to enable logging, the best place probably is the API server , where you would want handle JMX and log level settings.
Added the same for the api-server project.
![image](https://cloud.githubusercontent.com/assets/846306/17690925/5feea278-63af-11e6-97c4-415aef7076ff.png)
